### PR TITLE
Add shorter method aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ buffer.discardBufferedChanges(['address']); // Discard only the address property
 
 buffer.get('email'); // => example@example.com
 buffer.get('address'); // => 1717 rose street
+```
 
+You can also use these shorter method names
+
+```js
+buffer.discardChanges(); // equivalent to buffer.discardBufferedChanges()
+buffer.applyChanges();   // equivalent to buffer.applyBufferedChanges()
 ```
 
 Or you can grab the mixin directly

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -5,6 +5,13 @@ var get = Ember.get;
 var set = Ember.set;
 var keys = Ember.keys;
 var isArray = Ember.isArray;
+var computed = Ember.computed;
+
+function aliasMethod(methodName) {
+  return function() {
+    return this[methodName].apply(this, arguments);
+  };
+}
 
 function empty(obj) {
   var key;
@@ -20,6 +27,8 @@ export default Ember.Mixin.create({
     this.initializeBuffer();
     this.hasBufferedChanges = false;
   },
+
+  hasChanges: computed.readOnly('hasBufferedChanges'),
 
   initializeBuffer: function(onlyTheseKeys) {
     if(isArray(onlyTheseKeys) && !empty(onlyTheseKeys)) {
@@ -93,6 +102,8 @@ export default Ember.Mixin.create({
     }
   },
 
+  applyChanges: aliasMethod('applyBufferedChanges'),
+
   discardBufferedChanges: function(onlyTheseKeys) {
     var buffer = this.buffer;
 
@@ -110,5 +121,7 @@ export default Ember.Mixin.create({
     if (empty(this.buffer)) {
       this.set('hasBufferedChanges', false);
     }
-  }
+  },
+
+  discardChanges: aliasMethod('discardBufferedChanges'),
 });

--- a/tests/unit/mixin-test.js
+++ b/tests/unit/mixin-test.js
@@ -156,3 +156,23 @@ test("that apply/discard only these keys works", function() {
   equal(proxy.get('baz'), 1);
   equal(content.baz, 1);
 });
+
+test("aliased methods work", function() {
+  var BufferedProxy = Ember.ObjectProxy.extend(Mixin);
+
+  var proxy = BufferedProxy.create({
+    content: { property: 1 }
+  });
+
+  proxy.set('property', 2);
+  ok(proxy.get('hasChanges'), "Modified proxy has changes");
+
+  proxy.applyChanges();
+  equal(proxy.get('content.property'), 2, "Applying changes sets the content's property");
+  ok(!(proxy.get('hasChanges')), "Proxy has no changes after changes are applied");
+
+  proxy.set('baz', 3);
+  proxy.discardChanges();
+  equal(proxy.get('property'), 2, "Discarding changes resets the proxy's property");
+  ok(!(proxy.get('hasChanges')), "Proxy has no changes after changes are discarded");
+});


### PR DESCRIPTION
Pull request for https://github.com/yapplabs/ember-buffered-proxy/issues/4

Added:
- discardChanges()
- applyChanges()
- get(‘hasChanges’)

Let me know what you think! I kept the longer method names and added these shorter ones as aliases, but it would be fine the other way around as well.
