### PR TITLE
Fixed deprecations with Ember 1.13.3

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -6,7 +6,7 @@ import {
 
 var get        = Ember.get;
 var set        = Ember.set;
-var keys       = Ember.keys;
+var keys       = Object.keys;
 var isArray    = Ember.isArray;
 var computed   = Ember.computed;
 
@@ -30,7 +30,7 @@ export default Ember.Mixin.create({
       }, this);
     }
     else {
-      this.buffer = Ember.create(null);
+      this.buffer = Object.create(null);
     }
   },
 

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -6,7 +6,8 @@ import {
 
 var get        = Ember.get;
 var set        = Ember.set;
-var keys       = Object.keys;
+var keys       = Object.keys || Ember.keys;
+var create     = Object.create || Ember.create;
 var isArray    = Ember.isArray;
 var computed   = Ember.computed;
 
@@ -30,7 +31,7 @@ export default Ember.Mixin.create({
       }, this);
     }
     else {
-      this.buffer = Object.create(null);
+      this.buffer = create(null);
     }
   },
 


### PR DESCRIPTION
Changed `Ember.keys` to `Object.keys` and `Ember.create` to `Object.create` as per deprecations added in Ember 1.13.3.
