### PR TITLE
Add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An Ember Object Proxy (and mixin) the enables change buffering. Ever need to "hold back" property changes before they propogate? If so this may be the project for you.
 
+## DEPRECATED
+
+This project has been deprecated in light of the move away from proxy objects in Ember 2.0. It still works in Ember 1.x, but it uses private APIs, so may not continue to work for 2.0. For an alternative approach, check out @krisselden's [example](https://github.com/krisselden/draft-sample).
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
In light of @krisselden's comments on #12, seems like this project might be deprecated? If that's the case, a notice in the readme might be helpful so new projects can try using an alternative approach.

Not sure if it's actually being deprecated, but figured I'd send the PR along just in case.