### PR TITLE
Adding the ability to check prototype properties in setUnknownProperty

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -46,6 +46,15 @@ export default Ember.Mixin.create({
   },
 
   setUnknownProperty: function(key, value) {
+    var m = meta(this);
+
+    if (m.proto === this) {
+      // if marked as prototype then just defineProperty
+      // rather than delegate
+      defineProperty(this, key, null, value);
+      return value;
+    }
+
     var buffer  = this.buffer;
     var content = this.get('content');
     var current;

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -4,14 +4,16 @@ import {
   empty
 } from './helpers';
 
-var get        = Ember.get;
-var set        = Ember.set;
-var keys       = Object.keys || Ember.keys;
-var create     = Object.create || Ember.create;
-var isArray    = Ember.isArray;
-var computed   = Ember.computed;
+var get            = Ember.get;
+var set            = Ember.set;
+var keys           = Object.keys || Ember.keys;
+var create         = Object.create || Ember.create;
+var isArray        = Ember.isArray;
+var computed       = Ember.computed;
+var meta           = Ember.meta;
+var defineProperty = Ember.defineProperty;
 
-var hasOwnProp = Object.prototype.hasOwnProperty;
+var hasOwnProp     = Object.prototype.hasOwnProperty;
 
 export default Ember.Mixin.create({
   hasChanges     : computed.readOnly('hasBufferedChanges'),


### PR DESCRIPTION
If object is intended to be only a prototype then just defineProperty rather than delegate

Taken from Ember.ObjectProxy 
https://github.com/emberjs/ember.js/blob/v2.4.0/packages/ember-runtime/lib/mixins/-proxy.js#L86

It could be useful when you creating objects with container

```
let buffer = BufferedProxy.create(
    getOwner(this).ownerInjection(),
    {content: content}
);

```

Fix for issue https://github.com/yapplabs/ember-buffered-proxy/issues/22
