### PR TITLE
Allow defining additional values at create time.

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -4,7 +4,15 @@ import {
   empty
 } from './helpers';
 
-const { get, set, isArray, computed, getProperties } = Ember;
+const {
+  get,
+  set,
+  isArray,
+  computed,
+  getProperties,
+  defineProperty,
+  meta,
+} = Ember;
 
 const keys = Object.keys || Ember.keys;
 const create = Object.create || Ember.create;
@@ -13,7 +21,7 @@ const hasOwnProp = Object.prototype.hasOwnProperty;
 export default Ember.Mixin.create({
   buffer: null,
   hasBufferedChanges: false,
-  
+
   hasChanges: computed.readOnly('hasBufferedChanges'),
   applyChanges: aliasMethod('applyBufferedChanges'),
   discardChanges : aliasMethod('discardBufferedChanges'),
@@ -40,6 +48,15 @@ export default Ember.Mixin.create({
   },
 
   setUnknownProperty(key, value) {
+    const m = meta(this);
+
+    if (m.proto === this) {
+      // if marked as prototype then just defineProperty
+      // rather than delegate
+      defineProperty(this, key, null, value);
+      return value;
+    }
+
     const { buffer, content } = getProperties(this, ['buffer', 'content']);
     let current;
     let previous;

--- a/tests/unit/mixin-test.js
+++ b/tests/unit/mixin-test.js
@@ -163,3 +163,17 @@ test('aliased methods work', (assert) => {
   assert.equal(get(proxy, 'property'), 2, 'Discarding changes resets the proxy\'s property');
   assert.ok(!(get(proxy, 'hasChanges')), 'Proxy has no changes after changes are discarded');
 });
+
+test('allows passing other variables at .create time', (assert) => {
+  const BufferedProxy = Ember.ObjectProxy.extend(Mixin);
+  const fakeContainer = Ember.Object.create({});
+
+  var proxy = BufferedProxy.create({
+    content: { property: 1 },
+    container: fakeContainer,
+    foo: 'foo',
+  });
+
+  assert.equal(proxy.get('container'), fakeContainer, 'Proxy didn\'t allow defining container property at create time');
+  assert.equal(proxy.get('foo'), 'foo', 'Proxy didn\'t allow setting an arbitrary value at create time');
+});

--- a/tests/unit/mixin-test.js
+++ b/tests/unit/mixin-test.js
@@ -10,10 +10,10 @@ const { get, set } = Ember;
 module('ember-buffered-proxy/mixin');
 
 test('that it works', (assert) => {
-  const BufferedPorxy = Ember.ObjectProxy.extend(Mixin);
+  const BufferedProxy = Ember.ObjectProxy.extend(Mixin);
   const content = { baz: 1 };
 
-  const proxy = BufferedPorxy.create({ content });
+  const proxy = BufferedProxy.create({ content });
 
   assert.equal(get(proxy, 'baz'), 1);
   assert.equal(get(content, 'baz'), 1);
@@ -59,10 +59,10 @@ test('that it works', (assert) => {
 });
 
 test('that apply/discard only these keys works', (assert) => {
-  const BufferedPorxy = Ember.ObjectProxy.extend(Mixin);
+  const BufferedProxy = Ember.ObjectProxy.extend(Mixin);
   const content = { baz: 1, world: 'hello' };
 
-  const proxy = BufferedPorxy.create({ content });
+  const proxy = BufferedProxy.create({ content });
 
   assert.equal(get(proxy, 'baz'), 1);
   assert.equal(get(content, 'baz'), 1);


### PR DESCRIPTION
In some cases, like with ember-cp-validations, the BufferedProxy object itself needs a container. However, with the current implementation of setUnknownProperty, things break (as reported in #22).
With this changeset, setUnknownProperty becomes aware of whether or not it's called at the time of .create or at another time.
Fixes #22.
Also, credit to @elatonsev who had this fix on his fork but never PRed it.