### PR TITLE
Utilize notifyPropertyChange instead of property(Will|Did)Change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -12,6 +12,7 @@ const {
   getProperties,
   defineProperty,
   meta,
+  notifyPropertyChange,
 } = Ember;
 
 const keys = Object.keys || Ember.keys;
@@ -71,7 +72,6 @@ export default Ember.Mixin.create({
       return;
     }
 
-    this.propertyWillChange(key);
 
     if (current === value) {
       delete buffer[key];
@@ -83,7 +83,7 @@ export default Ember.Mixin.create({
       set(this, 'hasBufferedChanges', true);
     }
 
-    this.propertyDidChange(key);
+    notifyPropertyChange(this, key);
 
     return value;
   },
@@ -116,8 +116,7 @@ export default Ember.Mixin.create({
         return;
       }
 
-      this.propertyWillChange(key);
-      this.propertyDidChange(key);
+      notifyPropertyChange(this, key);
     });
 
     if (empty(get(this, 'buffer'))) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.6.0",
+    "ember-notify-property-change-polyfill": "^0.0.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,6 +2195,13 @@ ember-load-initializers@^1.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-notify-property-change-polyfill@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/ember-notify-property-change-polyfill/-/ember-notify-property-change-polyfill-0.0.1.tgz#636f75e2aaf67e2c56cb13e7139499226fd60d55"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-version-checker "^2.1.0"
+
 ember-qunit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.2.0.tgz#3cdf400031c93a38de781a7304819738753b7f99"


### PR DESCRIPTION
`propertyWillChange` and `propertyDidChange` are deprecated in Ember 3.1 and will be removed from the exports in Ember 3.5.  Unfortunately `notifyPropertyChange` isn't available on the global until versions of Ember > 3.1.  So the fix here is to use `this.notifyPropertyChange(key)` which should be available going back to 2.12 (which the test suites dummy app uses) and likely even earlier versions of Ember.

Please see deprecation link below for more details:

https://emberjs.com/deprecations/v3.x/#toc_use-notifypropertychange-instead-of-propertywillchange-and-propertydidchange