### PR TITLE
Add additional check for meta.isInitializing

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -51,9 +51,9 @@ export default Ember.Mixin.create({
   setUnknownProperty(key, value) {
     const m = meta(this);
 
-    if (m.proto === this) {
-      // if marked as prototype then just defineProperty
-      // rather than delegate
+    if (m.proto === this || (m.isInitializing && m.isInitializing())) {
+      // if marked as prototype or object is initializing then just
+      // defineProperty rather than delegate
       defineProperty(this, key, null, value);
       return value;
     }


### PR DESCRIPTION
The check for `m.proto === this` in `setUnknownProperty` was introduced to allow defining additional values at create time, especially in the case of using the ember-cp-validations addon.

This code, taken from the the Ember.ProxyMixin, has changed due to a refactor since 3.6, see:
https://github.com/emberjs/ember.js/commit/a80eba3d9876542e35837897042fe02b9f6f3f09#diff-9bf8bbd79c58f7c1479813cd250667ddL93

My issue was in combination with Ember 3.8 and ember-cp-validations having buffer changes just after creation. This PR simply adds another check for the new method `meta.isInitializing()` to skip buffer changes during initialization to be compatible with Ember 3.6+.