### PR TITLE
Fix Travis config after upgrading Ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      - env: EMBER_TRY_SCENARIO=ember-lts-3.8
-      - env: EMBER_TRY_SCENARIO=ember-release
-      - env: EMBER_TRY_SCENARIO=ember-beta
-      - env: EMBER_TRY_SCENARIO=ember-canary
-      - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+      env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-beta
+    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
When I was upgrading Ember and merging new addon output in https://github.com/yapplabs/ember-buffered-proxy/pull/49 I made a mistake in `.travis.yml`.

Apologies, I should verify if the file is valid 🤦‍♂ 

Here's the fix.