### PR TITLE
Fix buffer notification on changes discard

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -98,7 +98,7 @@ export default Mixin.create({
   },
 
   discardBufferedChanges(onlyTheseKeys) {
-    const buffer = get(this, 'buffer');
+    const { buffer, content } = getProperties(this, ['buffer', 'content']);
 
     this.initializeBuffer(onlyTheseKeys);
 
@@ -107,7 +107,7 @@ export default Mixin.create({
         return;
       }
 
-      notifyPropertyChange(this, key);
+      notifyPropertyChange(content, key);
     });
 
     if (empty(get(this, 'buffer'))) {

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -73,4 +73,30 @@ module('Acceptance | application', function(hooks) {
     assert.dom('#user-email').hasText('test@dot.com');
     assert.dom('#buffer-has-changes').hasText('false');
   });
+
+  test('verify if buffer is notified about discarding changes', async function(assert) {
+    await visit('/');
+
+    assert.equal(currentURL(), '/');
+
+    // Init: Buffer's and content's property value are the same
+    assert.dom('#buffer-firstname').hasText('stefan');
+    assert.dom('#buffer-firstname-backward').hasText('nafets');
+    assert.dom('#user-firstname').hasText('stefan');
+    assert.dom('#buffer-has-changes').hasText('false');
+
+    // Change buffer value: there should be a difference between buffer and content
+    await fillIn('#firstname-input', 'tomek');
+    assert.dom('#buffer-firstname').hasText('tomek');
+    assert.dom('#buffer-firstname-backward').hasText('kemot');
+    assert.dom('#user-firstname').hasText('stefan');
+    assert.dom('#buffer-has-changes').hasText('true');
+
+    // Discard buffer changes and verify
+    await click('button#discard-changes');
+    assert.dom('#buffer-firstname').hasText('stefan');
+    assert.dom('#buffer-firstname-backward').hasText('nafets');
+    assert.dom('#user-firstname').hasText('stefan');
+    assert.dom('#buffer-has-changes').hasText('false');
+  });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,7 +1,13 @@
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 import BufferedProxy from 'ember-buffered-proxy/proxy';
 
 export default Controller.extend({
+
+  computedOnBuffer: computed('buffer.firstName', function() {
+    return this.get('buffer.firstName').split('').reverse().join('');
+  }),
+
   init() {
     this._super(...arguments);
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,6 +4,8 @@
 <div id="buffer-email">{{buffer.email}}</div>
 <div id="user-email">{{user.email}}</div>
 
+<div id="buffer-firstname-backward">{{computedOnBuffer}}</div>
+
 <div id="buffer-has-changes">{{buffer.hasChanges}}</div>
 
 {{input id="firstname-input" value=buffer.firstName onChange=(action (mut buffer.firstName))}}


### PR DESCRIPTION
I realized that the buffer doesn't notify about changes on the `discardBufferedChanges` method.
I added a test that shows that. A computed property that depends on the buffered property is not notified about the change and it doesn't recompute on `discardBufferedChanges` action.