### PR TITLE
🐞 Conditionally choose notifyPropertyChange context based on Ember version

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -5,10 +5,21 @@ import { isArray } from '@ember/array';
 import { readOnly } from '@ember/object/computed';
 import { defineProperty, getProperties, set, get } from '@ember/object';
 
+import { gte, lte } from 'ember-compatibility-helpers';
+
 import { aliasMethod, empty } from './helpers';
 
 const { notifyPropertyChange, meta } = Ember; // eslint-disable-line ember/new-module-imports
 const hasOwnProp = Object.prototype.hasOwnProperty;
+
+function monkeyPatchedNotifyPropertyChange(context, key) {
+  if (gte('3.13.0') && lte('3.19.0')) {
+    let content = get(context, 'content');
+    notifyPropertyChange(content, key);
+  } else {
+    notifyPropertyChange(context, key);
+  }
+}
 
 export default Mixin.create({
   buffer: null,
@@ -74,7 +85,8 @@ export default Mixin.create({
       set(this, 'hasBufferedChanges', true);
     }
 
-    notifyPropertyChange(content, key);
+    
+    monkeyPatchedNotifyPropertyChange(this, key);
 
     return value;
   },
@@ -98,7 +110,7 @@ export default Mixin.create({
   },
 
   discardBufferedChanges(onlyTheseKeys) {
-    const { buffer, content } = getProperties(this, ['buffer', 'content']);
+    const buffer = get(this, 'buffer');
 
     this.initializeBuffer(onlyTheseKeys);
 
@@ -107,7 +119,7 @@ export default Mixin.create({
         return;
       }
 
-      notifyPropertyChange(content, key);
+      monkeyPatchedNotifyPropertyChange(this, key);
     });
 
     if (empty(get(this, 'buffer'))) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.11.1",
     "ember-cli-htmlbars": "^4.0.5",
+    "ember-compatibility-helpers": "^1.2.2",
     "ember-notify-property-change-polyfill": "^0.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,7 +1807,7 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-debug-macros@^0.2.0-beta.6:
+babel-plugin-debug-macros@^0.2.0, babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
   integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
@@ -4774,6 +4774,15 @@ ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-ve
     resolve-package-path "^1.2.6"
     semver "^5.6.0"
 
+ember-cli-version-checker@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz#649c7b6404902e3b3d69c396e054cea964911ab0"
+  integrity sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==
+  dependencies:
+    resolve-package-path "^3.1.0"
+    semver "^7.3.4"
+    silent-error "^1.1.1"
+
 ember-cli@~3.14.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.14.0.tgz#9a142da77aa8c95e0bc2c70acc67c9809e9e45cf"
@@ -4871,6 +4880,15 @@ ember-cli@~3.14.0:
     walk-sync "^2.0.2"
     watch-detector "^1.0.0"
     yam "^1.0.0"
+
+ember-compatibility-helpers@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.2.tgz#839e0c24190b7a2ec8c39b80e030811b1a95b6d3"
+  integrity sha512-EKyCGOGBvKkBsk6wKfg3GhjTvTTkcEwzl/cv4VYvZM18cihmjGNpliR4BymWsKRWrv4VJLyq15Vhk3NHkSNBag==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    semver "^5.4.1"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
@@ -7216,6 +7234,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-core-module@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -8436,6 +8461,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 make-array@^0.1.2:
   version "0.1.2"
@@ -10920,6 +10952,14 @@ resolve-package-path@^1.0.11, resolve-package-path@^1.2.2, resolve-package-path@
     path-root "^0.1.1"
     resolve "^1.10.0"
 
+resolve-package-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-3.1.0.tgz#35faaa5d54a9c7dd481eb7c4b2a44410c9c763d8"
+  integrity sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.17.0"
+
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
@@ -10952,6 +10992,14 @@ resolve@^1.1.6, resolve@^1.3.3, resolve@^1.4.0:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.17.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
+    path-parse "^1.0.6"
 
 responselike@1.0.2, responselike@^1.0.2:
   version "1.0.2"
@@ -11184,6 +11232,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.1.0:
   version "5.1.1"
@@ -13137,6 +13192,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yam@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# ✨ What Changed & Why

Somehow, Ember `v3.13.x` introduced a change that caused ember-buffered-proxy to stop working when calling notifyPropertyChange to update references to a buffered object.

As a result of this change, a "fix" was introduced to ember-buffered-proxy in
46d00d7 and 3f63beb which changed the way notifyPropertyChange was changed as follows:

```diff
- notifyPropertyChange(this, key);
+ notifyPropertyChange(content, key);
```

This seemed to fix the problem, although it doesn't conceptually make sense as to why (which is slightly worrying).

Fast forward to Ember `v3.20.x` and something else has changed in Ember source which has caused ember-buffered-proxy to stop working again. Or, more likely, whatever was introduced in Ember 3.13.x has been patched so that notifyPropertyChange, once again, requires `this` to be passed to it, as was originally the case.

This PR adds some version checking to ensure that notifyPropertyChange is called with the correct context depending on what version of Ember is being used.

I used [this sandbox](https://codesandbox.io/s/vibrant-browser-g4n7p?file=/package.json) to verify which versions required which arguments so that I could specifically target the right Ember versions. The following is the table of versions I have focussed on:

|Version| `notifyPropertyChange(this)` | `notifyPropertyChange(content)`|
|:-:|:-:|:-:|
|3.12|✅|❌|
|3.13|❌|✅|
|3.14|❌|✅|
|3.15|❌|✅|
|3.16|✅|✅|
|3.17|❌|✅|
|3.18|❌|✅|
|3.19|❌|✅|
|3.20|✅|❌|
|3.21|✅|❌|
|3.22|✅|❌|
|3.23|✅|❌|
|3.24|✅|❌|

I have also verified that this fix works on the following versions: `3.12`, `3.13`, `3.19` and `3.20` so I am confident that this covers all possibilities.

# Related Issues

Fixes #67 