### PR TITLE
Conditionally choose notifyPropertyChange context based on Ember version

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -6,10 +6,21 @@ import { isArray } from '@ember/array';
 import { readOnly } from '@ember/object/computed';
 import { defineProperty, getProperties, set, get } from '@ember/object';
 
+import { gte, lte } from 'ember-compatibility-helpers';
+
 import { aliasMethod, empty } from './helpers';
 
 const { notifyPropertyChange, meta } = Ember; // eslint-disable-line ember/new-module-imports
 const hasOwnProp = Object.prototype.hasOwnProperty;
+
+function monkeyPatchedNotifyPropertyChange(context, key) {
+  if (gte('3.13.0') && lte('3.19.0')) {
+    let content = get(context, 'content');
+    notifyPropertyChange(content, key);
+  } else {
+    notifyPropertyChange(context, key);
+  }
+}
 
 export default Mixin.create({
   buffer: null,
@@ -73,7 +84,7 @@ export default Mixin.create({
       set(this, 'hasBufferedChanges', true);
     }
 
-    notifyPropertyChange(content, key);
+    monkeyPatchedNotifyPropertyChange(this, key);
 
     return value;
   },
@@ -97,7 +108,7 @@ export default Mixin.create({
   },
 
   discardBufferedChanges(onlyTheseKeys) {
-    const { buffer, content } = getProperties(this, ['buffer', 'content']);
+    const buffer = get(this, 'buffer');
 
     this.initializeBuffer(onlyTheseKeys);
 
@@ -106,7 +117,7 @@ export default Mixin.create({
         return;
       }
 
-      notifyPropertyChange(content, key);
+      monkeyPatchedNotifyPropertyChange(this, key);
     });
 
     if (empty(get(this, 'buffer'))) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.3.1",
+    "ember-compatibility-helpers": "^1.2.6",
     "ember-notify-property-change-polyfill": "^0.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,6 +5897,17 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
     ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
+  integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    find-up "^5.0.0"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
 ember-destroyable-polyfill@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz"
@@ -7237,9 +7248,9 @@ fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
   dependencies:
     at-least-node "^1.0.0"


### PR DESCRIPTION
I cherry picked the changes from @achambers in #68 and updated `ember-compatibility-helpers` to `^1.2.6`.