### PR TITLE
Conditionally choose notifyPropertyChange context based on Ember version

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -1,5 +1,6 @@
 /* eslint-disable ember/no-get */
 /* eslint-disable ember/no-new-mixins */
+import Ember from 'ember';
 import Mixin from '@ember/object/mixin';
 import { isArray } from '@ember/array';
 import { readOnly } from '@ember/object/computed';
@@ -15,7 +16,7 @@ import { gte, lte } from 'ember-compatibility-helpers';
 
 import { aliasMethod, empty } from './helpers';
 
-import { meta as metaFor } from '@ember/-internals/meta';
+const { meta } = Ember; // eslint-disable-line ember/new-module-imports
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
 function monkeyPatchedNotifyPropertyChange(context, key) {
@@ -56,7 +57,7 @@ export default Mixin.create({
   },
 
   setUnknownProperty(key, value) {
-    const m = metaFor(this);
+    const m = meta(this);
 
     if (m.proto === this || (m.isInitializing && m.isInitializing())) {
       // if marked as prototype or object is initializing then just

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -6,10 +6,21 @@ import { isArray } from '@ember/array';
 import { readOnly } from '@ember/object/computed';
 import { defineProperty, getProperties, set, get } from '@ember/object';
 
+import { gte, lte } from 'ember-compatibility-helpers';
+
 import { aliasMethod, empty } from './helpers';
 
 const { notifyPropertyChange, meta } = Ember; // eslint-disable-line ember/new-module-imports
 const hasOwnProp = Object.prototype.hasOwnProperty;
+
+function monkeyPatchedNotifyPropertyChange(context, key) {
+  if (gte('3.13.0') && lte('3.19.0')) {
+    let content = get(context, 'content');
+    notifyPropertyChange(content, key);
+  } else {
+    notifyPropertyChange(context, key);
+  }
+}
 
 export default Mixin.create({
   buffer: null,
@@ -73,7 +84,7 @@ export default Mixin.create({
       set(this, 'hasBufferedChanges', true);
     }
 
-    notifyPropertyChange(content, key);
+    monkeyPatchedNotifyPropertyChange(this, key);
 
     return value;
   },
@@ -97,7 +108,7 @@ export default Mixin.create({
   },
 
   discardBufferedChanges(onlyTheseKeys) {
-    const { buffer, content } = getProperties(this, ['buffer', 'content']);
+    const buffer = get(this, 'buffer');
 
     this.initializeBuffer(onlyTheseKeys);
 
@@ -106,7 +117,7 @@ export default Mixin.create({
         return;
       }
 
-      notifyPropertyChange(content, key);
+      monkeyPatchedNotifyPropertyChange(this, key);
     });
 
     if (empty(get(this, 'buffer'))) {

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -3,7 +3,13 @@
 import Mixin from '@ember/object/mixin';
 import { isArray } from '@ember/array';
 import { readOnly } from '@ember/object/computed';
-import { defineProperty, getProperties, set, get, notifyPropertyChange } from '@ember/object';
+import {
+  defineProperty,
+  getProperties,
+  set,
+  get,
+  notifyPropertyChange,
+} from '@ember/object';
 
 import { gte, lte } from 'ember-compatibility-helpers';
 

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -1,16 +1,15 @@
 /* eslint-disable ember/no-get */
 /* eslint-disable ember/no-new-mixins */
-import Ember from 'ember';
 import Mixin from '@ember/object/mixin';
 import { isArray } from '@ember/array';
 import { readOnly } from '@ember/object/computed';
-import { defineProperty, getProperties, set, get } from '@ember/object';
+import { defineProperty, getProperties, set, get, notifyPropertyChange } from '@ember/object';
 
 import { gte, lte } from 'ember-compatibility-helpers';
 
 import { aliasMethod, empty } from './helpers';
 
-const { notifyPropertyChange, meta } = Ember; // eslint-disable-line ember/new-module-imports
+import { meta as metaFor } from '@ember/-internals/meta';
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
 function monkeyPatchedNotifyPropertyChange(context, key) {
@@ -51,7 +50,7 @@ export default Mixin.create({
   },
 
   setUnknownProperty(key, value) {
-    const m = meta(this);
+    const m = metaFor(this);
 
     if (m.proto === this || (m.isInitializing && m.isInitializing())) {
       // if marked as prototype or object is initializing then just

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "^5.7.2",
+    "ember-compatibility-helpers": "^1.2.6",
     "ember-notify-property-change-polyfill": "^0.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6903,6 +6903,17 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
     ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
+  integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    find-up "^5.0.0"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
 ember-destroyable-polyfill@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz#1673ed66609a82268ef270a7d917ebd3647f11e1"


### PR DESCRIPTION
I cherry picked the changes from @achambers in #68 and updated `ember-compatibility-helpers` to `^1.2.6`.